### PR TITLE
Only allow minors/patches dotenv-expand update versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "dependencies": {
     "@lykmapipo/common": ">=0.44.5",
     "dotenv": ">=10.0.0",
-    "dotenv-expand": ">=5.1.0",
+    "dotenv-expand": "~5.1.0",
     "lodash": ">=4.17.21",
     "rc": ">=1.2.8",
     "semver": ">=7.3.5"


### PR DESCRIPTION
I was using the express-respond lib and it started breaking my tests so I started digging around and found that the issue is that the code does not work with dotenv-expand >6 which has been [released a few days ago](https://github.com/motdotla/dotenv-expand/releases/tag/v6.0.0) because of the way it exports the function, so limiting the use to version 5 and its minor/patches versions.